### PR TITLE
Initializing the m_context attribute so we don't have warnings

### DIFF
--- a/Asteroids/Game.cpp
+++ b/Asteroids/Game.cpp
@@ -10,7 +10,8 @@ namespace Engine
 	Game::Game(const std::string& title, const int width, const int height)
 		:	m_title ( title  ),
 			m_width ( width  ),
-			m_height( height )
+			m_height( height ),
+			m_context( nullptr )
 	{
 		m_mainWindow = nullptr;
 		m_state = GameState::UNINITIALIZED;

--- a/Asteroids/Game.cpp
+++ b/Asteroids/Game.cpp
@@ -10,9 +10,9 @@ namespace Engine
 	Game::Game(const std::string& title, const int width, const int height)
 		:	m_title ( title  ),
 			m_width ( width  ),
-			m_height( height ),
-			m_context( nullptr )
+			m_height( height )
 	{
+		m_context = nullptr;
 		m_mainWindow = nullptr;
 		m_state = GameState::UNINITIALIZED;
 	}


### PR DESCRIPTION
Initializing the **m_context** attribute so that we don't have warnings in the project because of having a non initialized member in the class.
